### PR TITLE
[tests/platform/mellanox] check PSU state against sysfs on Mellanox d…

### DIFF
--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -134,6 +134,34 @@ def check_sysfs_cpu(dut):
         assert cpu_core_temp < cpu_core_max_temp, "CPU core%d overheated, temp: %s" % (core_id, str(cpu_core_temp))
 
 
+def check_psu_status_sysfs_consistency(dut, psu_id, psu_state):
+    """
+    @summary: Check psu related sysfs under /bsp/module against psu_state
+    """
+    psu_exist = "/bsp/module/psu%s_status" % psu_id
+    if psu_state == "NOT PRESENT":
+        psu_exist_content = dut.command("cat %s" % psu_exist)
+        logging.info("PSU state %s file %s read %s" % (psu_state, psu_exist, psu_exist_content["stdout"]))
+        assert psu_exist_content["stdout"] == "0", "CLI returns NOT PRESENT while %s contains %s" %  \
+                    (psu_exist, psu_exist_content["stdout"])
+    else:
+        from common.mellanox_data import SWITCH_MODELS
+        dut_hwsku = dut.facts["hwsku"]
+        hot_swappabe = SWITCH_MODELS[dut_hwsku]["psus"]["hot_swappable"]
+        if hot_swappabe:
+            psu_exist_content = dut.command("cat %s" % psu_exist)
+            logging.info("PSU state %s file %s read %s" % (psu_state, psu_exist, psu_exist_content["stdout"]))
+            assert psu_exist_content["stdout"] == "1", "CLI returns %s while %s contains %s" %  \
+                        (psu_state, psu_exist, psu_exist_content["stdout"])
+
+        psu_pwr_state = "/bsp/module/psu%s_pwr_status" % psu_id
+        psu_pwr_state_content = dut.command("cat %s" % psu_pwr_state)
+        logging.info("PSU state %s file %s read %s" % (psu_state, psu_pwr_state, psu_pwr_state_content["stdout"]))
+        assert (psu_pwr_state_content["stdout"] == "1" and psu_state == "OK") \
+                or (psu_pwr_state_content["stdout"] == "0" and psu_state == "NOT OK"),\
+            "sysfs content %s mismatches with psu_state %s" % (psu_pwr_state_content["stdout"], psu_state)
+
+
 def check_sysfs_psu(dut):
     logging.info("Check psu")
 
@@ -141,10 +169,8 @@ def check_sysfs_psu(dut):
     psu_count = SWITCH_MODELS[dut.facts["hwsku"]]["psus"]["number"]
 
     if SWITCH_MODELS[dut.facts["hwsku"]]["psus"]["hot_swappable"]:
-        psu_status_list = ["/bsp/module/psu%d_status" % psu_id for psu_id in range(1, psu_count + 1)]
-        for psu_status in psu_status_list:
-            psu_status_content = dut.command("cat %s" % psu_status)
-            assert psu_status_content["stdout"] == "1", "Content of %s is not 1" % psu_status
+        for psu_id in range(1, psu_count + 1):
+            check_psu_status_sysfs_consistency(dut, psu_id, 'OK')
 
 
 def check_sysfs_qsfp(dut, interfaces):
@@ -174,31 +200,3 @@ def check_sysfs(dut, interfaces):
     check_sysfs_psu(dut)
 
     check_sysfs_qsfp(dut, interfaces)
-
-def check_psu_sysfs(dut, psu_id, psu_state):
-    """
-    @summary: Check psu related sysfs under /bsp/module against psu_state
-    """
-    psu_exist = "/bsp/module/psu%s_status" % psu_id
-    if psu_state == "NOT PRESENT":
-        psu_exist_content = dut.command("cat %s" % psu_exist)
-        logging.info("PSU state %s file %s read %s" % (psu_state, psu_exist, psu_exist_content["stdout"]))
-        assert psu_exist_content["stdout"] == "0", "CLI returns NOT PRESENT while %s contains %s" %  \
-                    (psu_exist, psu_exist_content["stdout"])
-    else:
-        from common.mellanox_data import SWITCH_MODELS
-        dut_hwsku = dut.facts["hwsku"]
-        hot_swappabe = SWITCH_MODELS[dut_hwsku]["psus"]["hot_swappable"]
-        if hot_swappabe:
-            psu_exist_content = dut.command("cat %s" % psu_exist)
-            logging.info("PSU state %s file %s read %s" % (psu_state, psu_exist, psu_exist_content["stdout"]))
-            assert psu_exist_content["stdout"] == "1", "CLI returns %s while %s contains %s" %  \
-                        (psu_state, psu_exist, psu_exist_content["stdout"])
-
-        psu_pwr_state = "/bsp/module/psu%s_pwr_status" % psu_id
-        psu_pwr_state_content = dut.command("cat %s" % psu_pwr_state)
-        logging.info("PSU state %s file %s read %s" % (psu_state, psu_pwr_state, psu_pwr_state_content["stdout"]))
-        assert (psu_pwr_state_content["stdout"] == "1" and psu_state == "OK") \
-                or (psu_pwr_state_content["stdout"] == "0" and psu_state == "NOT OK"),\
-            "sysfs content %s mismatches with psu_state %s" % (psu_pwr_state_content["stdout"], psu_state)
-

--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -174,3 +174,31 @@ def check_sysfs(dut, interfaces):
     check_sysfs_psu(dut)
 
     check_sysfs_qsfp(dut, interfaces)
+
+def check_psu_sysfs(dut, psu_id, psu_state):
+    """
+    @summary: Check psu related sysfs under /bsp/module against psu_state
+    """
+    psu_exist = "/bsp/module/psu%s_status" % psu_id
+    if psu_state == "NOT PRESENT":
+        psu_exist_content = dut.command("cat %s" % psu_exist)
+        logging.info("PSU state %s file %s read %s" % (psu_state, psu_exist, psu_exist_content["stdout"]))
+        assert psu_exist_content["stdout"] == "0", "CLI returns NOT PRESENT while %s contains %s" %  \
+                    (psu_exist, psu_exist_content["stdout"])
+    else:
+        from common.mellanox_data import SWITCH_MODELS
+        dut_hwsku = dut.facts["hwsku"]
+        hot_swappabe = SWITCH_MODELS[dut_hwsku]["psus"]["hot_swappable"]
+        if hot_swappabe:
+            psu_exist_content = dut.command("cat %s" % psu_exist)
+            logging.info("PSU state %s file %s read %s" % (psu_state, psu_exist, psu_exist_content["stdout"]))
+            assert psu_exist_content["stdout"] == "1", "CLI returns %s while %s contains %s" %  \
+                        (psu_state, psu_exist, psu_exist_content["stdout"])
+
+        psu_pwr_state = "/bsp/module/psu%s_pwr_status" % psu_id
+        psu_pwr_state_content = dut.command("cat %s" % psu_pwr_state)
+        logging.info("PSU state %s file %s read %s" % (psu_state, psu_pwr_state, psu_pwr_state_content["stdout"]))
+        assert (psu_pwr_state_content["stdout"] == "1" and psu_state == "OK") \
+                or (psu_pwr_state_content["stdout"] == "0" and psu_state == "NOT OK"),\
+            "sysfs content %s mismatches with psu_state %s" % (psu_pwr_state_content["stdout"], psu_state)
+

--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -168,9 +168,8 @@ def check_sysfs_psu(dut):
     from common.mellanox_data import SWITCH_MODELS
     psu_count = SWITCH_MODELS[dut.facts["hwsku"]]["psus"]["number"]
 
-    if SWITCH_MODELS[dut.facts["hwsku"]]["psus"]["hot_swappable"]:
-        for psu_id in range(1, psu_count + 1):
-            check_psu_status_sysfs_consistency(dut, psu_id, 'OK')
+    for psu_id in range(1, psu_count + 1):
+        check_psu_status_sysfs_consistency(dut, psu_id, 'OK')
 
 
 def check_sysfs_qsfp(dut, interfaces):

--- a/tests/platform/test_platform_info.py
+++ b/tests/platform/test_platform_info.py
@@ -48,14 +48,14 @@ def check_vendor_specific_psustatus(dut, psu_status_line):
         sub_folder_dir = os.path.join(current_file_dir, "mellanox")
         if sub_folder_dir not in sys.path:
             sys.path.append(sub_folder_dir)
-        from check_sysfs import check_psu_sysfs
+        from check_sysfs import check_psu_status_sysfs_consistency
 
         psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
         psu_match = psu_line_pattern.match(psu_status_line)
         psu_id = psu_match.group(1)
         psu_status = psu_match.group(2)
 
-        check_psu_sysfs(dut, psu_id, psu_status)
+        check_psu_status_sysfs_consistency(dut, psu_id, psu_status)
 
 def test_show_platform_psustatus(testbed_devices):
     """


### PR DESCRIPTION
…evices (#1082)

* [psu test case] check psu state against vendor specific info. for mellanox, check sysfs

* [test_platform_info.py]handle "NOT PRESENT" in test_show_platform_psustatus

* [psu testcase] address comments

Conflicts:
	tests/platform/mellanox/check_sysfs.py

* [check_sysfs] rewords.

* [check_sysfs.py] rewording

Conflicts:
	tests/platform/mellanox/check_sysfs.py

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
