### PR TITLE
[pytest]Add sfp plug in/out test with FW simulation

### DIFF
--- a/tests/platform/mellanox/files/sfpadminset.py
+++ b/tests/platform/mellanox/files/sfpadminset.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+import sys
+import errno
+import os
+from python_sdk_api.sxd_api import *
+from python_sdk_api.sx_api import *
+
+REGISTER_NUM = 1
+SXD_LOG_VERBOSITY_LEVEL = 0
+DEVICE_ID = 1
+SWITCH_ID = 0
+SX_PORT_ATTR_ARR_SIZE = 64
+
+PMAOS_ASE = 1
+PMAOS_EE = 1
+PMAOS_E = 2
+PMAOS_RST = 0
+PMAOS_ENABLE = 1
+PMAOS_DISABLE = 2
+PMAOS_DISCONNECT = 14
+
+PORT_TYPE_NVE = 8
+PORT_TYPE_OFFSET = 28
+PORT_TYPE_MASK = 0xF0000000
+NVE_MASK = PORT_TYPE_MASK & (PORT_TYPE_NVE << PORT_TYPE_OFFSET)
+
+
+def is_nve(port):
+    return (port & NVE_MASK) != 0
+
+
+def is_port_admin_status_up(logic_port):
+    oper_state_p = new_sx_port_oper_state_t_p()
+    admin_state_p = new_sx_port_admin_state_t_p()
+    module_state_p = new_sx_port_module_state_t_p()
+    rc = sx_api_port_state_get(handle, logic_port, oper_state_p, admin_state_p, module_state_p)
+    assert rc == SXD_STATUS_SUCCESS, "sx_api_port_state_get failed, rc = %d" % rc
+
+    admin_state = sx_port_admin_state_t_p_value(admin_state_p)
+    if admin_state == SX_PORT_ADMIN_STATUS_UP:
+        return True
+    else:
+        return False
+
+
+def set_port_admin_status_by_log_port(sdk_handle, logic_port, admin_status):
+    rc = sx_api_port_state_set(sdk_handle, logic_port, admin_status)
+    assert rc == SX_STATUS_SUCCESS, "sx_api_port_state_set failed, rc = %d" % rc
+
+
+# Get all the ports related to the sfp, if port admin status is up, put it to list
+def get_log_ports(sdk_handle, sfp_module):
+    port_attributes_list = new_sx_port_attributes_t_arr(SX_PORT_ATTR_ARR_SIZE)
+    port_cnt_p = new_uint32_t_p()
+    uint32_t_p_assign(port_cnt_p, SX_PORT_ATTR_ARR_SIZE)
+
+    rc = sx_api_port_device_get(sdk_handle, DEVICE_ID, SWITCH_ID, port_attributes_list,  port_cnt_p)
+    assert rc == SX_STATUS_SUCCESS, "sx_api_port_device_get failed, rc = %d" % rc
+
+    port_cnt = uint32_t_p_value(port_cnt_p)
+    log_port_list = []
+    for i in range(0, port_cnt):
+        port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list, i)
+        if not is_nve(int(port_attributes.log_port)) \
+           and port_attributes.port_mapping.module_port == sfp_module:
+            log_port_list.append(port_attributes.log_port)
+
+    return log_port_list
+
+
+def init_sx_meta_data():
+    meta = sxd_reg_meta_t()
+    meta.dev_id = DEVICE_ID
+    meta.swid = SWITCH_ID
+    return meta
+
+
+def set_sfp_admin_status(sfp_module, admin_status):
+    # Get PMAOS
+    pmaos = ku_pmaos_reg()
+    pmaos.module = sfp_module
+    meta = init_sx_meta_data()
+    meta.access_cmd = SXD_ACCESS_CMD_GET
+    rc = sxd_access_reg_pmaos(pmaos, meta, REGISTER_NUM, None, None)
+    assert rc == SXD_STATUS_SUCCESS, "sxd_access_reg_pmaos failed, rc = %d" % rc
+
+    # Set admin status to PMAOS
+    pmaos.ase = PMAOS_ASE
+    pmaos.ee = PMAOS_EE
+    pmaos.e = PMAOS_E
+    pmaos.rst = PMAOS_RST
+    pmaos.admin_status = admin_status
+
+    meta.access_cmd = SXD_ACCESS_CMD_SET
+    rc = sxd_access_reg_pmaos(pmaos, meta, REGISTER_NUM, None, None)
+    assert rc == SXD_STATUS_SUCCESS, "sxd_access_reg_pmaos failed, rc = %d" % rc
+
+
+# Check if all parameters provided
+if len(sys.argv) < 3:
+    print "SFP module number or SFP Operation is missed."
+    print "Usage: sfplpmset.py <SFP module> <connect|disconnect>"
+    sys.exit(errno.EINVAL)
+
+# Get SFP module from first arg
+sfp_module_id = int(sys.argv[1])
+
+# Get SFP operation from second arg
+sfp_disconnect = None
+if sys.argv[2] == 'disconnect':
+    sfp_disconnect = True
+elif sys.argv[2] == 'connect':
+    sfp_disconnect = False
+else:
+    print "Unrecognized SFP parameter. Please use <connect> or <disconnect> values"
+    sys.exit(errno.EINVAL)
+
+# Init SDK API
+result, handle = sx_api_open(None)
+if result != SX_STATUS_SUCCESS:
+    print "Failed to open api handle.\nPlease check that SDK is running."
+    sys.exit(errno.EACCES)
+
+pid = os.getpid()
+result = sxd_access_reg_init(pid, None, SXD_LOG_VERBOSITY_LEVEL)
+if result != SXD_STATUS_SUCCESS:
+    print "Failed to initializing register access.\nPlease check that SDK is running."
+    sys.exit(errno.EACCES)
+
+if sfp_disconnect:
+    # Get all ports that related to the SFP module
+    logic_port_list = get_log_ports(handle, sfp_module_id)
+
+    # Set all this SFP related ports to admin down status
+    for log_port in logic_port_list:
+        print('log_port: 0x%x' % log_port)
+        set_port_admin_status_by_log_port(handle, log_port, SX_PORT_ADMIN_STATUS_DOWN)
+
+    # Set PMAOS to disconnect
+    set_sfp_admin_status(sfp_module_id, PMAOS_DISCONNECT)
+else:
+    # In theory we should set the PMAOS back to enable, but by
+    # set log_port to admin status up, it will automatically set
+    # the PMAOS to enable, so we can save this step and only need
+    # to set the log_port to admin up.
+
+    # Get all ports that related to the SFP module
+    logic_port_list = get_log_ports(handle, sfp_module_id)
+
+    # Set all this SFP related ports to admin up status
+    for log_port in logic_port_list:
+        print('log_port: 0x%x' % log_port)
+        set_port_admin_status_by_log_port(handle, log_port, SX_PORT_ADMIN_STATUS_UP)

--- a/tests/platform/mellanox/test_check_sfp_plug_in_out_sim.py
+++ b/tests/platform/mellanox/test_check_sfp_plug_in_out_sim.py
@@ -44,7 +44,6 @@ def verify_interface_status(dut, mg_ports, intf, status_up_expected):
 def verify_sfp_presence_status(dut, intf, presence_expected):
     check_intf_presence_command = 'show interface transceiver presence {}'
     check_presence_output = dut.command(check_intf_presence_command.format(intf))
-    assert check_presence_output["rc"] == 0, "Failed to read interface %s transceiver presence" % intf
     logging.info(str(check_presence_output["stdout_lines"][2]))
     presence_list = check_presence_output["stdout_lines"][2].split()
     logging.info(str(presence_list))
@@ -59,7 +58,6 @@ def verify_sfp_presence_sysfs_status(dut, sfp_id, presence_expected):
     check_qsfp_sysfs_command = 'cat /var/run/hw-management/qsfp/qsfp{}_status'
     check_sysfs_output = dut.command(check_qsfp_sysfs_command.format(str(sfp_id)))
     logging.info('output of check sysfs %s' % (str(check_sysfs_output)))
-    assert check_sysfs_output["rc"] == 0, "Failed to read qsfp_status of sfp%s." % str(sfp_id)
     if presence_expected:
         assert check_sysfs_output["stdout"] == '1', "Content of qsfp_status of sfp%s is not correct" % str(sfp_id)
     else:

--- a/tests/platform/mellanox/test_check_sfp_plug_in_out_sim.py
+++ b/tests/platform/mellanox/test_check_sfp_plug_in_out_sim.py
@@ -1,0 +1,109 @@
+"""
+Test SFP plug in/out behavior via simulation
+"""
+import logging
+import os
+import json
+import time
+
+from platform_fixtures import conn_graph_facts
+from check_interface_status import parse_intf_status
+
+
+def verfy_interface_status(dut, mg_ports, intf, status_up_expected):
+    shutdown_intf_command = 'config interface shutdown {}'
+    startup_intf_command = 'config interface startup {}'
+    
+    if intf not in mg_ports:
+        dut.command(startup_intf_command.format(intf))
+        dut.command(shutdown_intf_command.format(intf))
+    else:
+        output = dut.command("intfutil description")
+        intf_status = parse_intf_status(output["stdout_lines"][2:])
+        if status_up_expected:
+            expected_oper = "up"
+            expected_admin = "up"
+        else:
+            expected_oper = "down"
+            expected_admin = "up"
+        assert intf in intf_status, "Missing status for interface %s" % intf
+        assert intf_status[intf]["oper"] == expected_oper, \
+            "Oper status of interface %s is %s, expected '%s'" % (intf, intf_status[intf]["oper"], expected_oper)
+        assert intf_status[intf]["admin"] == expected_admin, \
+            "Admin status of interface %s is %s, expected '%s'" % (intf, intf_status[intf]["admin"], expected_admin)
+
+
+def verify_sfp_presence_status(dut, intf, presence_expected):
+    check_intf_presence_command = 'show interface transceiver presence {}'
+    check_presence_output = dut.command(check_intf_presence_command.format(intf))
+    assert check_presence_output["rc"] == 0, "Failed to read interface %s transceiver presence" % intf
+    logging.info(str(check_presence_output["stdout_lines"][2]))
+    presence_list = check_presence_output["stdout_lines"][2].split()
+    logging.info(str(presence_list))
+    assert intf in presence_list, "Wrong interface name in the output %s" % str(presence_list)
+    if presence_expected:
+        assert 'Present' in presence_list, "Status is not expected, output %s" % str(presence_list)
+    else:
+        assert 'Present' not in presence_list, "Status is not expected, output %s" % str(presence_list)
+
+
+def verify_sfp_presence_sysfs_status(dut, sfp_id, presence_expected):
+    check_qsfp_sysfs_command = 'cat /var/run/hw-management/qsfp/qsfp{}_status'
+    check_sysfs_output = dut.command(check_qsfp_sysfs_command.format(str(sfp_id)))
+    logging.info('output of check sysfs %s' % (str(check_sysfs_output)))
+    assert check_sysfs_output["rc"] == 0, "Failed to read qsfp_status of sfp%s." % str(sfp_id)
+    if presence_expected:
+        assert check_sysfs_output["stdout"] == '1', "Content of qsfp_status of sfp%s is not correct" % str(sfp_id)
+    else:
+        assert check_sysfs_output["stdout"] == '0', "Content of qsfp_status of sfp%s is not correct" % str(sfp_id)
+
+
+def test_check_sfp_plug_in_out_sim(testbed_devices, conn_graph_facts):
+    """This test case is to check SFP presence, sysfs status 
+       and interface staus by simulating SFP plug in/out via PMAOS
+    """
+    ans_host = testbed_devices["dut"]
+    logging.debug('platform : %s, hwsku : %s, ASIC %s' % (ans_host.facts['platform'], ans_host.facts['hwsku'],
+                                                          ans_host.facts['asic_type']))
+    dest_path = os.path.join('/usr/share/sonic/device', ans_host.facts['platform'], 'plugins/sfpadminset.py')
+    src_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'files/sfpadminset.py')
+    logging.debug('src = %s, dest = %s' % (src_path, dest_path))
+    ans_host.copy(src=src_path, dest=dest_path)
+    
+    mg_ports = ans_host.minigraph_facts(host=ans_host.hostname)["ansible_facts"]["minigraph_ports"]
+
+    ports_config = json.loads(ans_host.command("sudo sonic-cfggen -d --var-json PORT")["stdout"])
+
+    sfp_disconnect_command = \
+        'docker exec -it syncd python /usr/share/sonic/platform/plugins/sfpadminset.py {} "disconnect"'
+    sfp_connect_command = \
+        'docker exec -it syncd python /usr/share/sonic/platform/plugins/sfpadminset.py {} "connect"'
+
+    logging.info("Use show interface status information")
+    for intf in mg_ports:
+        intf_lanes = ports_config[intf]["lanes"]
+        sfp_id = int(intf_lanes.split(",")[0])/4 + 1
+        sdk_port_id = int(intf_lanes.split(",")[0])/4
+
+        # Init check, expect port is up, SFP is presence
+        verify_sfp_presence_sysfs_status(ans_host, sfp_id, True)
+        verify_sfp_presence_status(ans_host, intf, True)
+        verfy_interface_status(ans_host, mg_ports, intf, True)
+
+        # Disconnect SFP to simulate SFP plug out
+        ans_host.command(sfp_disconnect_command.format(sdk_port_id))
+
+        # Expecting port is down, SFP not presence
+        verify_sfp_presence_status(ans_host, intf, False)
+        verify_sfp_presence_sysfs_status(ans_host, sfp_id, False)
+        verfy_interface_status(ans_host, mg_ports, intf, False)
+
+        # Connect SFP to simulate SFP plug in
+        ans_host.command(sfp_connect_command.format(sdk_port_id))
+        # It needs about 10s to have ports go up
+        time.sleep(10)
+
+        # Check again, expect SFP restored, and port become up again
+        verify_sfp_presence_status(ans_host, intf, True)
+        verify_sfp_presence_sysfs_status(ans_host, sfp_id, True)
+        verfy_interface_status(ans_host, mg_ports, intf, True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Add a new sfp plug in/out test. 
sfp plug in/out is simulated by some way provide by FW.

***There is still an FW bug that blocks this test from running on testbeds with ports split.
on testbed w/o ports split it work well.***

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
upload a script to DUT which can simulate sfp plug in/out.
during the test run the script and check SFP information in the DB and also the interface status.

#### How did you verify/test it?
Run this test on the Mellanox platform 

#### Any platform specific information?
This is Mellanox specific test

#### Supported testbed topology if it's a new test case?
All topology

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
