### PR TITLE
[pytest] WA for the fan default speed check issue

### DIFF
--- a/tests/platform/mellanox/check_hw_mgmt_service.py
+++ b/tests/platform/mellanox/check_hw_mgmt_service.py
@@ -3,6 +3,7 @@ Helper function for checking the hw-management service
 """
 import logging
 import re
+import time
 
 from common.utilities import wait_until
 
@@ -20,7 +21,9 @@ def check_hw_management_service(dut):
     """This function is to check the hw management service and related settings.
     """
     logging.info("Check fan speed setting")
-    assert not wait_until_fan_speed_set_to_default(dut), \
+    # Wait for 300 secs to make sure fan speed is set to default value 
+    time.sleep(300)
+    assert fan_speed_set_to_default(dut), \
         "Fan speed is not default to 60 percent in 5 minutes. 153/255=60%"
 
     logging.info("Check service status using systemctl")

--- a/tests/platform/mellanox/check_hw_mgmt_service.py
+++ b/tests/platform/mellanox/check_hw_mgmt_service.py
@@ -21,7 +21,13 @@ def check_hw_management_service(dut):
     """This function is to check the hw management service and related settings.
     """
     logging.info("Check fan speed setting")
-    # Wait for 300 secs to make sure fan speed is set to default value 
+    # In current hw-mgmt implementation, it set the fan speed to default
+    # value when suspending thermal control algorithm, but it takes some time
+    # to take effect. During this period, algorithm could change speed value
+    # back and hw-mgmt will set it to default again, so it's possible that
+    # although at some point the speed value is default but it could be changed
+    # after some time. So we just wait for 300 secs to make sure fan speed is
+    # set to default value instead of check every 10s.
     time.sleep(300)
     assert fan_speed_set_to_default(dut), \
         "Fan speed is not default to 60 percent in 5 minutes. 153/255=60%"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The current mechanism to check whether the fan speed was set to default is to check it every 10s and if true will stop, considering the facts that after hw-mgmt set the fan speed to the default value, it could be changed and hw-mgmt will set it again, only after a while(may more than 2m) it can be stable. So change the way to wait for 300s to make sure fan speed set to default and not change anymore.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
using sleep() to replace wait_until.

#### How did you verify/test it?
test it with various type of reboot

#### Any platform specific information?
This modification is Mellanox specific.

#### Supported testbed topology if it's a new test case?
All test bed

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
