### PR TITLE
[pytest]Stop sensord in psu test

### DIFF
--- a/tests/platform/test_platform_info.py
+++ b/tests/platform/test_platform_info.py
@@ -19,10 +19,8 @@ CMD_PLATFORM_SUMMARY = "show platform summary"
 CMD_PLATFORM_PSUSTATUS = "show platform psustatus"
 CMD_PLATFORM_SYSEEPROM = "show platform syseeprom"
 
-ans_host = None
 
-
-def check_sensord_status():
+def check_sensord_status(ans_host):
     """
     @summary: Check sensord running status by analyzing the output of "ps -x" and return the PID if it's running
     """
@@ -37,30 +35,40 @@ def check_sensord_status():
     return running_status, sensord_pid
 
 
-def stop_pmon_sensord_task():
+def stop_pmon_sensord_task(ans_host):
     """
     @summary: Stop sensord task of pmon docker if it's running.
     """
-    sensord_running_status, sensord_pid = check_sensord_status()
+    sensord_running_status, sensord_pid = check_sensord_status(ans_host)
     if sensord_running_status:
         ans_host.command("docker exec pmon kill -SIGTERM {}".format(sensord_pid))
 
-    sensord_running_status, sensord_pid = check_sensord_status()
+    sensord_running_status, sensord_pid = check_sensord_status(ans_host)
     if sensord_running_status:
         logging.info("failed to stop sensord task")
     else:
         logging.info("sensord stopped successfully")
 
 
-def teardown_module():
+@pytest.fixture(scope="module")
+def psu_test_setup_teardown(testbed_devices):
     """
-    @summary: restart the sensord task of pmon if it was killed in the PSU test
+    @summary: Sensord task will print out error msg when detect PSU offline,
+              which can cause log analyzer fail the test. So stop sensord task
+              before test and restart it after all test finished.
     """
-    sensord_running_status, sensord_pid = check_sensord_status()
+    logging.info("Starting psu test setup")
+    ans_host = testbed_devices["dut"]
+    stop_pmon_sensord_task(ans_host)
+
+    yield
+
+    logging.info("Starting psu test teardown")
+    sensord_running_status, sensord_pid = check_sensord_status(ans_host)
     if not sensord_running_status:
         ans_host.command("docker exec pmon supervisorctl restart lm-sensors")
         time.sleep(3)
-        sensord_running_status, sensord_pid = check_sensord_status()
+        sensord_running_status, sensord_pid = check_sensord_status(ans_host)
         if sensord_running_status:
             logging.info("sensord task restarted, pid = {}".format(sensord_pid))
         else:
@@ -73,7 +81,7 @@ def test_show_platform_summary(testbed_devices):
     """
     @summary: Check output of 'show platform summary'
     """
-    global ans_host
+    # global ans_host
     ans_host = testbed_devices["dut"]
 
     logging.info("Check output of '%s'" % CMD_PLATFORM_SUMMARY)
@@ -111,7 +119,6 @@ def test_show_platform_psustatus(testbed_devices):
     """
     @summary: Check output of 'show platform psustatus'
     """
-    global ans_host
     ans_host = testbed_devices["dut"]
 
     logging.info("Check PSU status using '%s', hostname: %s" % (CMD_PLATFORM_PSUSTATUS, ans_host.hostname))
@@ -122,17 +129,11 @@ def test_show_platform_psustatus(testbed_devices):
         check_vendor_specific_psustatus(ans_host, line)
 
 
-def test_turn_on_off_psu_and_check_psustatus(testbed_devices, psu_controller):
+def test_turn_on_off_psu_and_check_psustatus(testbed_devices, psu_controller, psu_test_setup_teardown):
     """
     @summary: Turn off/on PSU and check PSU status using 'show platform psustatus'
     """
-    global ans_host
     ans_host = testbed_devices["dut"]
-
-    # Sensord task will print out error msg when detect PSU offline,
-    # which can cause log analyzer fail the test. So stop sensord task
-    # before test and restart it after all test finished.
-    stop_pmon_sensord_task()
 
     psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
     cmd_num_psu = "sudo psuutil numpsus"
@@ -225,7 +226,6 @@ def test_show_platform_syseeprom(testbed_devices):
     """
     @summary: Check output of 'show platform syseeprom'
     """
-    global ans_host
     ans_host = testbed_devices["dut"]
 
     logging.info("Check output of '%s'" % CMD_PLATFORM_SYSEEPROM)

--- a/tests/platform/test_platform_info.py
+++ b/tests/platform/test_platform_info.py
@@ -32,6 +32,8 @@ def check_sensord_status(ans_host):
         if "/usr/sbin/sensord" in key_value:
             running_status = True
             sensord_pid = int(key_value[0])
+            break
+
     return running_status, sensord_pid
 
 
@@ -45,7 +47,7 @@ def stop_pmon_sensord_task(ans_host):
 
     sensord_running_status, sensord_pid = check_sensord_status(ans_host)
     if sensord_running_status:
-        logging.info("failed to stop sensord task")
+        assert False, "Failed to stop sensord task before test."
     else:
         logging.info("sensord stopped successfully")
 
@@ -72,7 +74,7 @@ def psu_test_setup_teardown(testbed_devices):
         if sensord_running_status:
             logging.info("sensord task restarted, pid = {}".format(sensord_pid))
         else:
-            logging.info("sensord task not restarted")
+            assert False, "Failed to restart sensord task after test."
     else:
         logging.info("sensord is running, pid = {}".format(sensord_pid))
 

--- a/tests/platform/test_platform_info.py
+++ b/tests/platform/test_platform_info.py
@@ -81,7 +81,6 @@ def test_show_platform_summary(testbed_devices):
     """
     @summary: Check output of 'show platform summary'
     """
-    # global ans_host
     ans_host = testbed_devices["dut"]
 
     logging.info("Check output of '%s'" % CMD_PLATFORM_SUMMARY)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
During PSU test, while PSU turned off, sensord could print out error msg against offline PSU, this will fail the test since log analyzer will detect these error logs.

To avoid this failure, stop sensord before starting the PSU test, and restart it after all tests finished.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add function to detect sensord task status, and functions to stop/restart.
Before start the PSU test, check the sensord running status and stop it if it's running.
In the teardown function of the test, restart sensord task if it was stopped.

#### How did you verify/test it?
Run the platform test and analyze the log.
Platform info test passed with the change, sensord stopped before the test and restarted after the test, all behavior is expected.

#### Any platform specific information?
Applicable to all platform

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
