### PR TITLE
[copp_test] Increase the PPS_LIMIT_MAX to absorb the deviation in slower server case

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -32,7 +32,7 @@ class ControlPlaneBaseTest(BaseTest):
     MAX_PORTS = 128
     PPS_LIMIT = 600
     PPS_LIMIT_MIN = PPS_LIMIT * 0.9
-    PPS_LIMIT_MAX = PPS_LIMIT * 1.1
+    PPS_LIMIT_MAX = PPS_LIMIT * 1.3
     NO_POLICER_LIMIT = PPS_LIMIT * 1.4
     TARGET_PORT = "3"  # Historically we have port 3 as a target port
     TASK_TIMEOUT = 300  # Wait up to 5 minutes for tasks to complete


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary: Increase the PPS_LIMIT_MAX to absorb the deviation caused by a slower server.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

  Encounter random test failure on different trap groups with copp policer attached, when it failed the rx_pps is higher than the PPS_LIMIT_MAX. 

  After investigation found that this is due to the deviation of rx_pps calculation on a slower server. 
Although we expect that the PTF should be able to finish all the packets sending in DEFAULT_SEND_INTERVAL_SEC (10s), on a slower server it may need to take more time, so extra DEFAULT_RECEIVE_WAIT_TIME (3s) has already been added. 

  But we shall also consider the deviation in the rx_pps calculation in this case. As my test, from the TCP dump on DUT, arp request can still be received on the 11th or 12th second, worst case 13th second, the calculation of the rx_pps is taking DEFAULT_SEND_INTERVAL_SEC(10s), in the worst case the deviation can be 30%, so the PPS_LIMIT_MAX should be increased from 1.1 to 1.3 times of PPS_LIMIT to cover the worst case.

#### How did you do it?

Increase the PPS_LIMIT_MAX to PPS_LIMIT * 1.3

#### How did you verify/test it?

Run copp test cases and it passing

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
