### PR TITLE
[Platform API] Fix the thermal get_name platform API test

### DIFF
--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -50,24 +50,24 @@ class TestThermalApi(PlatformApiTestBase):
     # Helper functions
     #
 
-    def compare_value_with_platform_facts(self, duthost, key, value, thermal_idx):
-        expected_value = None
+    def compare_value_with_platform_facts(self, duthost, key, value):
+        expected_values = []
         if duthost.facts.get("chassis").get("thermals"):
             expected_thermals = duthost.facts.get("chassis").get("thermals")
             if expected_thermals:
-                expected_value = expected_thermals[thermal_idx].get(key)
+                for thermal in expected_thermals:
+                    thermal_name = thermal.get(key)
+                    if thermal_name:
+                        expected_values.append(thermal_name)
 
-        if self.expect(expected_value is not None,
-                       "Unable to get expected value for '{}' from platform.json file for thermal {}".format(key,
-                                                                                                             thermal_idx)):
-            self.expect(value == expected_value,
-                        "'{}' value is incorrect. Got '{}', expected '{}' for thermal {}".format(key, value,
-                                                                                                 expected_value,
-                                                                                                 thermal_idx))
-
+        if self.expect(len(expected_values) > 0,
+                       "Unable to get thermal name list containing thermal '{}' from platform.json file".format(value)):
+            self.expect(value in expected_values, "Thermal name '{}' is not included in {}".format(value,
+                                                                                                   expected_values))
     #
     # Functions to test methods inherited from DeviceBase class
     #
+
     def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_thermals):
@@ -75,7 +75,7 @@ class TestThermalApi(PlatformApiTestBase):
 
             if self.expect(name is not None, "Unable to retrieve Thermal {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Thermal {} name appears incorrect".format(i))
-                self.compare_value_with_platform_facts(duthost, 'name', name, i)
+                self.compare_value_with_platform_facts(duthost, 'name', name)
 
         self.assert_expectations()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

In the test when it‘s getting the thermal sensor name from platform.json, it's using an 'index' same as PSU and FAN.
But thermal sensors are not like PSUs or FANs, when platform API init them, there could be no strict order, so use index may not be able to get the same sensor name every time. So should change the way to collect all the sensors' names to a list and use "in" to judge whether the sensor name is in the list.  

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

The test assuming thermal sensors have an index same as PSU and FAN, each time it's expecting use same index should get the same sensor, but this could be not true since thermal sensors don't have an index.

#### How did you do it?

Collect all the expected thermal sensor names to a list, and use 'in' to judge whether the sensor name get from "get_name" API are in the list. 

#### How did you verify/test it?

run test: platform_tests/api/test_thermal.py::TestThermalApi::test_get_name

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
