### PR TITLE
[platform_test/api] enhance lpmode api test

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -176,6 +176,14 @@ class TestSfpApi(PlatformApiTestBase):
             return False
         return True
 
+    def is_xcvr_support_lpmode(self, xcvr_info_dict):
+        """Returns True if transceiver is support low power mode, False if not supported"""
+        xcvr_type = xcvr_info_dict["type"]
+        ext_identifier = xcvr_info_dict["ext_identifier"]
+        if not "QSFP" in xcvr_type or "Power Class 1" in ext_identifier:
+            return False
+        return True
+
     #
     # Functions to test methods inherited from DeviceBase class
     #
@@ -452,7 +460,7 @@ class TestSfpApi(PlatformApiTestBase):
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
                 continue
 
-            if not self.is_xcvr_optical(info_dict):
+            if not self.is_xcvr_support_lpmode(info_dict):
                 logger.warning("test_lpmode: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
                 continue
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

To enhance the platform SFP low power mode API test case by adding a function to judge whether the transceiver is supporting low power mode. Currently, it only judges whether the transceiver is an optical one, this is not enough.
Also, set lpmode needs some time to take effect, need to add some delay to get the status again after set.

#### How did you do it?

Add a new function to judge whether the transceiver is support low power mode, if not, skip the transceiver in the test case.
the criteria to judge whether a transceiver is supporting low power mode:
1. whether the transceiver is a QSFP module, SFP/SFP+ don't support lpmode.
2. whether the transceiver's power class is higher than 'Power Class 1'

Use wait_until to add some delay before checking the lpmode status after the set operation.

#### How did you verify/test it?

run the test case on various types of transceivers

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
