### PR TITLE
[Mellanox] Enhance check_sysfs to ignore expected broken symbol links

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -10,12 +10,18 @@ from tests.common.utilities import wait_until
 
 MAX_FAN_SPEED_THRESHOLD = 0.15
 
+
 def skip_ignored_broken_symbolinks(broken_symbolinks):
     """
-    @summary: Check all the broken symbol links, skip the expected ones
+    @summary: Check all the broken symbol links found, remove the expected ones
+    examples for the expected broken symbol links:
+      /var/run/hw-management/led/led_psu2_green_delay_off
+      /var/run/hw-management/led/led_uid_blue_delay_on
+      /var/run/hw-management/led/led_fan_green_delay_on
+      /var/run/hw-management/led/led_status_red_delay_on
     """
-    # Currently some led bilinking related sysfs are expected to be broken after system boot up,
-    # so skip these expected sysfs and remove them from the check list
+    # Currently some led blinking related sysfs are expected to be broken after system boot up,
+    # so skip and remove them from the check list.
     broken_symbolinks_updated = []
     pattern = re.compile(".*led_.*_delay_(off|on)")
 
@@ -23,7 +29,6 @@ def skip_ignored_broken_symbolinks(broken_symbolinks):
 
     for symbolink in broken_symbolinks.splitlines():
         if not pattern.match(symbolink):
-            logging.info("not expected broken link: {}".format(symbolink))
             broken_symbolinks_updated.append(pattern)
         else:
             logging.info("ignore expected broken link: {}".format(symbolink))

--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -29,7 +29,7 @@ def skip_ignored_broken_symbolinks(broken_symbolinks):
 
     for symbolink in broken_symbolinks.splitlines():
         if not pattern.match(symbolink):
-            broken_symbolinks_updated.append(pattern)
+            broken_symbolinks_updated.append(symbolink)
         else:
             logging.info("ignore expected broken link: {}".format(symbolink))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Enhance check_sysfs to ignore expected broken symbol links.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

With the Mellanox new hw-managenet package release, some symbol links are expected to be broken after boot up, they should be excluded from the broken symbol link check. Add a function to match these expected broken symbol links and remove them from the check list.

#### How did you do it?

Add a new function, with a re pattern and match the broken links, exclude them from the  sysfs checklist.

#### How did you verify/test it?

run the platform_tests/mellanox/test_check_sysfs.py  on various Mellanox platforms

#### Any platform specific information?

This change only happened in the Mellanox specific test cases.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
